### PR TITLE
escompress@^0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "through": "^2.3.8",
-    "escompress": "https://github.com/escompress/escompress"
+    "escompress": "^0.5.0",
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
When pulling down escompress from github, the `lib/` directory is not included. This changes package.json to use the version of escompress that is published to npm, which includes `lib/`.